### PR TITLE
Add export to json/csv feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 *.py[cod]
 *$py.class
 .coverage
+data.json
+data.csv

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 ah-cli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,17 +13,23 @@ def cli(ctx):
 
 @cli.command()
 @click.argument("article_id")
-def view(article_id):
+@click.option('--export', '-e', type=click.Choice(["json"]))
+def view(article_id, export):
     """
     View single article
     """
-    GetArticles.get_single_article(article_id)
+    GetArticles.get_single_article(article_id, export)
 
 
 @cli.command()
 @click.option("--limit", "-l", type=int, default=None)
-def list(limit):
+@click.option(
+        '--export', '-e',
+        type=click.Choice(["csv", "json"]),
+        default=None
+        )
+def list(limit, export):
     """
     Return list of all articles
     """
-    GetArticles.get_all_articles(limit)
+    GetArticles.get_all_articles(limit, export)

--- a/app/get_articles.py
+++ b/app/get_articles.py
@@ -6,6 +6,7 @@ from app.utils import (
         url,
         check_connection,
         json_formatter,
+        export_json_csv,
         )
 
 
@@ -15,7 +16,7 @@ class GetArticles:
     """
 
     @staticmethod
-    def get_single_article(article_id):
+    def get_single_article(article_id, export):
         """
         Returns article with matching article_id
         """
@@ -24,6 +25,7 @@ class GetArticles:
         response = requests.get(url + "/articles/{}/".format(article_id))
         spinner.stop()
         spinner.clear()
+
         if response.status_code == 404:
             spinner.warn("The article requested was not found 😬")
             click.echo("Status code: {}".format(response.status_code))
@@ -32,9 +34,12 @@ class GetArticles:
             click.echo("Status code: {}".format(response.status_code))
             article = json_formatter(response.text)
             click.echo(article)
+            if export:
+                #  limited to 1 article by default
+                export_json_csv(article, export, limit=True)
 
     @staticmethod
-    def get_all_articles(limit):
+    def get_all_articles(limit, export):
         """
         Returns article with matching article_id
         """
@@ -51,3 +56,5 @@ class GetArticles:
 
         articles = json_formatter(response.text, limit)
         click.echo(articles)
+        if export:
+            export_json_csv(articles, export, limit)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,7 @@
 import sys
 import requests
 import json
+import csv
 
 from halo import Halo
 
@@ -32,3 +33,26 @@ def json_formatter(data, limit=None):
         return json.dumps(limited_json_data, indent=2)
 
     return json.dumps(json_data, indent=2)
+
+
+def export_json_csv(data, _format, limit):
+    data = json.loads(data)
+
+    if not limit:
+        data = data["results"]
+
+    if _format == "json":
+        with open('data.json', 'w', encoding='utf-8') as json_file:
+            json.dump(data, json_file, indent=2)
+    elif _format == "csv":
+        with open('data.csv', 'w', encoding='utf-8') as csv_file:
+            csv_writer = csv.writer(csv_file)
+            count = 0
+            for article_data in data:
+                if count == 0:
+                    header = article_data.keys()
+                    csv_writer.writerow(header)
+                    count += 1
+                csv_writer.writerow(article_data.values())
+
+    spinner.succeed("Exported to {} 🚀".format(_format))

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,26 @@
+#  TODO: Mock test file read/write
+from app import view, list
+
+
+def test_export_view_json(runner):
+    """
+    Tests exporting single article to json
+    """
+    res = runner.invoke(view, ["new_wangonya", "-e", "json"])
+    assert res.exit_code == 0
+
+
+def test_export_list_json(runner):
+    """
+    Tests exporting articles list to json
+    """
+    res = runner.invoke(list, ["-e", "json"])
+    assert res.exit_code == 0
+
+
+def test_export_list_csv(runner):
+    """
+    Tests exporting articles list to csv
+    """
+    res = runner.invoke(list, ["-e", "csv"])
+    assert res.exit_code == 0


### PR DESCRIPTION
#### What does this PR do?
Adds export to json/csv feature
#### How should this be manually tested?
* Clone repo: `$ git clone https://github.com/wangonya/ah-cli.git`
* Enter directory and activate env: `$ cd ah-cli && . .env`
* Export existing article to json: `(env) $ ah view new_wangonya -e json`  `# --export instead of -e would also work`
* Export list of articles to json : `(env) $ ah list -e json`
* Export list of articles to csv : `(env) $ ah list -e csv`